### PR TITLE
update to handle a2a changes - type key -> kind, switch OnSendTask to… … OnSendMessage

### DIFF
--- a/a2a/types.py
+++ b/a2a/types.py
@@ -24,7 +24,7 @@ class TaskState(str, Enum):
 
 
 class TextPart(BaseModel):
-    type: Literal['text'] = 'text'
+    kind: Literal['text'] = 'text'
     text: str
     metadata: dict[str, Any] | None = None
 
@@ -49,23 +49,37 @@ class FileContent(BaseModel):
 
 
 class FilePart(BaseModel):
-    type: Literal['file'] = 'file'
+    kind: Literal['file'] = 'file'
     file: FileContent
     metadata: dict[str, Any] | None = None
 
 
 class DataPart(BaseModel):
-    type: Literal['data'] = 'data'
+    kind: Literal['data'] = 'data'
     data: dict[str, Any]
     metadata: dict[str, Any] | None = None
 
 
-Part = Annotated[TextPart | FilePart | DataPart, Field(discriminator='type')]
+Part = Annotated[TextPart | FilePart | DataPart, Field(discriminator='kind')]
 
 
 class Message(BaseModel):
     role: Literal['user', 'agent']
     parts: list[Part]
+    messageId: str = Field(default_factory=lambda: uuid4().hex)
+    metadata: dict[str, Any] | None = None
+
+
+class MessageResponse(BaseModel):
+    contextId: str = ""
+    kind: str = "message"  # Make this more flexible to handle empty strings
+    messageId: str
+    parts: list[Part]
+    role: Literal['user', 'agent']
+
+
+class MessageSendParams(BaseModel):
+    message: Message
     metadata: dict[str, Any] | None = None
 
 
@@ -173,16 +187,16 @@ class JSONRPCResponse(JSONRPCMessage):
 
 
 class SendTaskRequest(JSONRPCRequest):
-    method: Literal['tasks/send'] = 'tasks/send'
-    params: TaskSendParams
+    method: Literal['message/send'] = 'message/send'
+    params: MessageSendParams
 
 
 class SendTaskResponse(JSONRPCResponse):
-    result: Task | None = None
+    result: MessageResponse | None = None
 
 
 class SendTaskStreamingRequest(JSONRPCRequest):
-    method: Literal['tasks/sendSubscribe'] = 'tasks/sendSubscribe'
+    method: Literal['tasks/sendMessageSubscribe'] = 'tasks/sendMessageSubscribe'
     params: TaskSendParams
 
 

--- a/handlers.py
+++ b/handlers.py
@@ -5,46 +5,41 @@ from slack_bolt import Say, Ack, BoltContext
 import os
 import uuid
 from a2a.client import A2AClient
+from a2a.types import Message, TextPart, MessageSendParams, MessageResponse
 
 async def invoke_a2a_agent(agent_url: str, input: str, logger: Logger):
     """
     Invokes the A2A agent and returns the response.
     """
     a2a_client = A2AClient(url=agent_url, timeout=600.0)
-    task_id = str(uuid.uuid4())
-    session_id = str(uuid.uuid4())
 
-    payload = {
-        "id": task_id,
-        "sessionId": session_id,
-        "acceptedOutputModes": ["text"],
-        "message": {
-            "role": "user",
-            "parts": [
-                {
-                    "type": "text",
-                    "text": input,
-                }
-            ]
-        }
-    }
+    # Create Pydantic models
+    text_part = TextPart(text=input)
+    message = Message(role="user", parts=[text_part])
+
+    # Create MessageSendParams
+    message_params = MessageSendParams(
+        message=message,
+        metadata={}
+    )
 
     logger.info(f"Invoking the agent: {agent_url}")
 
+    # Convert to dict for the client
+    payload = message_params.model_dump()
     response = await a2a_client.send_task(payload)
     text = ""
-    for artifact in response.result.artifacts:
-        for part in artifact.parts:
-            text += part.text
+    # The API returns the message directly in the result
+    if response.result and response.result.parts:
+        for part in response.result.parts:
+            if hasattr(part, 'text'):
+                text += part.text
     return text
-
-
 
 async def mykagent_command(
     client: WebClient, ack: Ack, command, say: Say, logger: Logger, context: BoltContext
 ):
     await ack()
-
 
     user_id = context["user_id"]
     channel_id = context["channel_id"]
@@ -72,8 +67,7 @@ async def mykagent_command(
         response = await invoke_a2a_agent(kagent_a2a_url, text, logger)
         await client.chat_postMessage(
             channel=channel_id,
-            user=user_id,
-            text=response,
+            text=f"*Agent Response:*\n{response}",
         )
     except Exception as e:
         logger.error(f"Error: {e}")


### PR DESCRIPTION
Updates to handle new A2A format:

Fixes 400 error owing to type key rather than kind:
```
ERROR:main.py:mykagent_command:Error: HTTP Error 400: Client error '400 Bad Request' for url 'http://127.0.0.1:8083/api/a2a/kagent/my-k8s-agent/'
```

Fixes 500 error owing to OnSendTask rather than OnSendMessage:
```
HTTP Error Response: {"jsonrpc":"2.0","id":"ba546ce058ef45148cea1a53652d6b74","error":{"code":-32603,"message":"Internal error","data":"task processing failed: OnSendTask is deprecated, use OnSendMessage instead"}}
```

Example successful invocation following the tutorial config:
```
INFO:main.py:mykagent_command:Invoking the agent: http://127.0.0.1:8083/api/a2a/kagent/my-k8s-agent/
INFO:httpx:HTTP Request: POST http://127.0.0.1:8083/api/a2a/kagent/my-k8s-agent/ "HTTP/1.1 200 OK"
```